### PR TITLE
Add items that were missing from the glossary

### DIFF
--- a/glossary/glossary.mdx
+++ b/glossary/glossary.mdx
@@ -21,6 +21,15 @@ Represents a custom identifier for your records that you have the option of sett
 
 The external reference must only be unique per group and is therefore used in conjunciton with groups in the API.
 
+## Unit
+A unit is a residential space, such as an apartment or single-family home, that is self-contained.
+
+## Person
+A person is any individual, including prospects, leaseholders, and occupants.
+
+## Flex
+Flex is a term used to describe a space where an additional bedroom has been created in an apartment through use of a temporary wall.
+
 ## Amenity
 An attribute associated with listings.
 


### PR DESCRIPTION
## What is the goal of this PR?

A few terms have been lost when the glossary was moved. This commit re-adds the missing items.