### PR TITLE
Add more fine grained authorization errors

### DIFF
--- a/api-reference/lease/find-leases-for-tenant.mdx
+++ b/api-reference/lease/find-leases-for-tenant.mdx
@@ -187,7 +187,17 @@ Status Code - 400
 ```
 
 Status Code - 401
-```json Invalid/Expired Authorization header bearer token value
+```json Expired Authorization header bearer token value
+{
+   "error": {
+    "type": "expired_token",
+    "message": "The bearer token you have provided in the 'Authorization' header has expired. Please obtain a new one."
+  }
+}
+```
+
+Status Code - 401
+```json Invalid Authorization header bearer token value
 {
    "error": {
     "type": "invalid_authorization",

--- a/api-reference/lease/find-tenants.mdx
+++ b/api-reference/lease/find-tenants.mdx
@@ -138,7 +138,17 @@ Status Code - 400
 ```
 
 Status Code - 401
-```json Invalid/Expired Authorization header bearer token value
+```json Expired Authorization header bearer token value
+{
+   "error": {
+    "type": "expired_token",
+    "message": "The bearer token you have provided in the 'Authorization' header has expired. Please obtain a new one."
+  }
+}
+```
+
+Status Code - 401
+```json Invalid Authorization header bearer token value
 {
    "error": {
     "type": "invalid_authorization",

--- a/api-reference/lease/find.mdx
+++ b/api-reference/lease/find.mdx
@@ -216,7 +216,17 @@ Status Code - 400
 ```
 
 Status Code - 401
-```json Invalid/Expired Authorization header bearer token value
+```json Expired Authorization header bearer token value
+{
+   "error": {
+    "type": "expired_token",
+    "message": "The bearer token you have provided in the 'Authorization' header has expired. Please obtain a new one."
+  }
+}
+```
+
+Status Code - 401
+```json Invalid Authorization header bearer token value
 {
    "error": {
     "type": "invalid_authorization",

--- a/api-reference/lease/post.mdx
+++ b/api-reference/lease/post.mdx
@@ -123,7 +123,17 @@ Status Code - 400
 ```
 
 Status Code - 401
-```json Invalid/Expired Authorization header bearer token value
+```json Expired Authorization header bearer token value
+{
+   "error": {
+    "type": "expired_token",
+    "message": "The bearer token you have provided in the 'Authorization' header has expired. Please obtain a new one."
+  }
+}
+```
+
+Status Code - 401
+```json Invalid Authorization header bearer token value
 {
    "error": {
     "type": "invalid_authorization",

--- a/api-reference/listing/delete.mdx
+++ b/api-reference/listing/delete.mdx
@@ -53,7 +53,17 @@ Status Code - 400
 ```
 
 Status Code - 401
-```json Invalid/Expired Authorization header bearer token value
+```json Expired Authorization header bearer token value
+{
+   "error": {
+    "type": "expired_token",
+    "message": "The bearer token you have provided in the 'Authorization' header has expired. Please obtain a new one."
+  }
+}
+```
+
+Status Code - 401
+```json Invalid Authorization header bearer token value
 {
    "error": {
     "type": "invalid_authorization",

--- a/api-reference/listing/find.mdx
+++ b/api-reference/listing/find.mdx
@@ -187,7 +187,17 @@ Status Code - 400
 ```
 
 Status Code - 401
-```json Invalid/Expired Authorization header bearer token value
+```json Expired Authorization header bearer token value
+{
+   "error": {
+    "type": "expired_token",
+    "message": "The bearer token you have provided in the 'Authorization' header has expired. Please obtain a new one."
+  }
+}
+```
+
+Status Code - 401
+```json Invalid Authorization header bearer token value
 {
    "error": {
     "type": "invalid_authorization",

--- a/api-reference/listing/post.mdx
+++ b/api-reference/listing/post.mdx
@@ -306,7 +306,17 @@ Status Code - 400
 ```
 
 Status Code - 401
-```json Invalid/Expired Authorization header bearer token value
+```json Expired Authorization header bearer token value
+{
+   "error": {
+    "type": "expired_token",
+    "message": "The bearer token you have provided in the 'Authorization' header has expired. Please obtain a new one."
+  }
+}
+```
+
+Status Code - 401
+```json Invalid Authorization header bearer token value
 {
    "error": {
     "type": "invalid_authorization",

--- a/api-reference/person/find.mdx
+++ b/api-reference/person/find.mdx
@@ -109,7 +109,17 @@ Status Code - 400
 ```
 
 Status Code - 401
-```json Invalid/Expired Authorization header bearer token value
+```json Expired Authorization header bearer token value
+{
+   "error": {
+    "type": "expired_token",
+    "message": "The bearer token you have provided in the 'Authorization' header has expired. Please obtain a new one."
+  }
+}
+```
+
+Status Code - 401
+```json Invalid Authorization header bearer token value
 {
    "error": {
     "type": "invalid_authorization",

--- a/api-reference/person/post-multiple.mdx
+++ b/api-reference/person/post-multiple.mdx
@@ -147,7 +147,17 @@ Status Code - 400
 ```
 
 Status Code - 401
-```json Invalid/Expired Authorization header bearer token value
+```json Expired Authorization header bearer token value
+{
+   "error": {
+    "type": "expired_token",
+    "message": "The bearer token you have provided in the 'Authorization' header has expired. Please obtain a new one."
+  }
+}
+```
+
+Status Code - 401
+```json Invalid Authorization header bearer token value
 {
    "error": {
     "type": "invalid_authorization",

--- a/api-reference/unit/find.mdx
+++ b/api-reference/unit/find.mdx
@@ -187,14 +187,23 @@ Status Code - 400
 ```
 
 Status Code - 401
-```json Invalid/Expired Authorization header bearer token value
+```json Expired Authorization header bearer token value
+{
+   "error": {
+    "type": "expired_token",
+    "message": "The bearer token you have provided in the 'Authorization' header has expired. Please obtain a new one."
+  }
+}
+```
+
+Status Code - 401
+```json Invalid Authorization header bearer token value
 {
    "error": {
     "type": "invalid_authorization",
     "message": "The bearer token you have provided in the 'Authorization' header is invalid."
   }
 }
-
 ```
 
 Status Code - 404

--- a/api-reference/unit/post-multiple.mdx
+++ b/api-reference/unit/post-multiple.mdx
@@ -216,14 +216,23 @@ Status Code - 400
 ```
 
 Status Code - 401
-```json Invalid/Expired Authorization header bearer token value
+```json Expired Authorization header bearer token value
+{
+   "error": {
+    "type": "expired_token",
+    "message": "The bearer token you have provided in the 'Authorization' header has expired. Please obtain a new one."
+  }
+}
+```
+
+Status Code - 401
+```json Invalid Authorization header bearer token value
 {
    "error": {
     "type": "invalid_authorization",
     "message": "The bearer token you have provided in the 'Authorization' header is invalid."
   }
 }
-
 ```
 
 Status Code - 400


### PR DESCRIPTION
## What is the goal of this PR?

Instead of returning a single error for expired and invalid authorization tokens we are returning separate ones. This way users will know whether their token is expired, which means they need to generate a new one or whether the token is invalid.