### PR TITLE
Moved query params to body parameters

### DIFF
--- a/api-reference/lease/find-leases-for-tenant.mdx
+++ b/api-reference/lease/find-leases-for-tenant.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Find Leases For Tenant"
-api: "POST https://api.travtus.com/leases/find-for-tenant?after-id={after-id}/"
+api: "POST https://api.travtus.com/leases/find-for-tenant/"
 description: "This endpoint finds leases for a specific tenant based on provided parameters."
 ---
 
@@ -31,14 +31,6 @@ You can retrieve all leases for a tenant given their phone number or email addre
   The authentication token for your request
 </ParamField>
 
-### Query
-
-<ParamField query="after-id" type="string" default="1">
-  The API returns a maximum of 10 records per call.
-  
-  You can use this query parameter to load the next set of records by passing in the value returned in the response, under `last_id`.
-</ParamField>
-
 ### Body
 
 <ParamField body="identifier" type="string" default="none">
@@ -67,12 +59,18 @@ You can retrieve all leases for a tenant given their phone number or email addre
   This is needed if passing the external_ref as the tenant identifier.
 </ParamField>
 
+<ParamField body="after-id" type="string" default="1">
+  The API returns a maximum of 100 records per call.
+  
+  You can use this parameter to load the next set of records by passing in the value returned in the response, under `last_id`.
+</ParamField>
+
 ### Response
 
 <ResponseField name="last_id" type="integer">
   The last id in the set of results returned for this API call.
 
-  You can use this value in the `after-id` query parameter to load the next set of results.
+  You can use this value in the `after-id` parameter to load the next set of results.
 
   If there are no more results to load, this value will be -1.
 </ResponseField>

--- a/api-reference/lease/find-tenants.mdx
+++ b/api-reference/lease/find-tenants.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Find Tenants"
-api: "POST https://api.travtus.com/leases/tenants?after-id={after-id}/"
+api: "POST https://api.travtus.com/leases/tenants/"
 description: "This endpoint returns a list of tenants filtered with the specified parameters."
 ---
 
@@ -21,14 +21,6 @@ You can retrieve tenants with a lease at a particular address, with the possibil
 
 <ParamField header="Authorization" type="string" default="none" required>
   The authentication token for your request
-</ParamField>
-
-### Query
-
-<ParamField query="after-id" type="string" default="1">
-  The API returns a maximum of 10 records per call.
-  
-  You can use this query parameter to load the next set of records by passing in the value returned in the response, under `last_id`.
 </ParamField>
 
 ### Body
@@ -83,6 +75,12 @@ You can retrieve tenants with a lease at a particular address, with the possibil
   </Expandable>
 </ParamField>
 
+<ParamField body="after-id" type="string" default="1">
+  The API returns a maximum of 100 records per call.
+
+  You can use this parameter to load the next set of records by passing in the value returned in the response, under `last_id`.
+</ParamField>
+
 ### Response
 
 <ResponseField name="tenants" type="string">
@@ -118,7 +116,7 @@ You can retrieve tenants with a lease at a particular address, with the possibil
 <ResponseField name="last_id" type="integer">
   The last id in the set of results returned for this API call.
 
-  You can use this value in the `after-id` query parameter to load the next set of results.
+  You can use this value in the `after-id` parameter to load the next set of results.
 
   If there are no more results to load, this value will be -1.
 </ResponseField>

--- a/api-reference/lease/find.mdx
+++ b/api-reference/lease/find.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Find Leases"
-api: "POST https://api.travtus.com/leases/find?after-id={after-id}/"
+api: "POST https://api.travtus.com/leases/find/"
 description: "This endpoint returns information about all leases that match the given parameters."
 ---
 
@@ -21,14 +21,6 @@ You can retrieve leases for a given address, with the possibility of narrowing o
 
 <ParamField header="Authorization" type="string" default="none" required>
   The authentication token for your request
-</ParamField>
-
-### Query
-
-<ParamField query="after-id" type="string" default="1">
-  The API returns a maximum of 10 records per call.
-
-  You can use this query parameter to load the next set of records by passing in the value returned in the response, under `last_id`.
 </ParamField>
 
 ### Body
@@ -93,6 +85,12 @@ You can retrieve leases for a given address, with the possibility of narrowing o
       The address' longitude.
     </ParamField>
   </Expandable>
+</ParamField>
+
+<ParamField body="after-id" type="string" default="1">
+  The API returns a maximum of 100 records per call.
+
+  You can use this parameter to load the next set of records by passing in the value returned in the response, under `last_id`.
 </ParamField>
 
 ### Response
@@ -196,7 +194,7 @@ You can retrieve leases for a given address, with the possibility of narrowing o
 <ResponseField name="last_id" type="integer">
   The last id in the set of results returned for this API call.
 
-  You can use this value in the `after-id` query parameter to load the next set of results.
+  You can use this value in the `after-id` parameter to load the next set of results.
 
   If there are no more results to load, this value will be -1.
 </ResponseField>

--- a/api-reference/listing/delete.mdx
+++ b/api-reference/listing/delete.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delete A Listing
-api: "DELETE https://api.travtus.com/listings/{listing-id}?inactive_date={inactive-date}/"
+api: "DELETE https://api.travtus.com/listings/{listing-id}/"
 description: "This endpoint delets a listing with the provided ID."
 ---
 
@@ -20,9 +20,9 @@ All date fields included in the body parameters need to be specified as [ISO8601
   The id of the listing to be deleted
 </ParamField>
 
-### Query
+### Body
 
-<ParamField path="inactive-date" type="date" default="Current date" required>
+<ParamField body="inactive-date" type="date" default="Current date" required>
   The date at which the listing should be deleted.
 
   If left empty, it defaults to the current date
@@ -77,9 +77,12 @@ Returned if the currently authenticated user does not have permission to delete 
 <RequestExample>
 
 ```bash Example Request
-curl --location --request "DELETE 'https://api.travtus.com/listings/listing-id-1?inactive_date=2012-01-23/' \
+curl --location --request "DELETE 'https://api.travtus.com/listings/listing-id-1/' \
 --header 'Content-Type: application/json' \
---header 'Authorization: bearer <token>'
+--header 'Authorization: bearer <token>' \
+--data-raw '{
+  "inactive_date": "2012-01-23"
+}
 ```
 
 </RequestExample>

--- a/api-reference/listing/find.mdx
+++ b/api-reference/listing/find.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Find Listings"
-api: "POST https://api.travtus.com/listings/find?after-id={after-id}/"
+api: "POST https://api.travtus.com/listings/find/"
 description: "This endpoint finds listings for the provided parameters."
 ---
 
@@ -16,14 +16,6 @@ This endpoint only returns vacancies that are active.
   The authentication token for your request.
 </ParamField>
 
-### Query
-
-<ParamField query="after-id" type="string" default="1">
-  The API returns a maximum of 10 records per call.
-  
-  You can use this query parameter to load the next set of records by passing in the value returned in the response, under `last_id`.
-</ParamField>
-
 ### Body
 
 <ParamField body="group" type="string" default="none">
@@ -34,12 +26,18 @@ This endpoint only returns vacancies that are active.
   The internal identifier of the listings to retrieve.
 </ParamField>
 
+<ParamField body="after-id" type="string" default="1">
+  The API returns a maximum of 100 records per call.
+  
+  You can use this parameter to load the next set of records by passing in the value returned in the response, under `last_id`.
+</ParamField>
+
 ### Response
 
 <ResponseField name="last_id" type="integer">
   The last id in the set of results returned for this API call.
 
-  You can use this value in the `after-id` query parameter to load the next set of results.
+  You can use this value in the `after-id` parameter to load the next set of results.
 
   If there are no more results to load, this value will be -1.
 </ResponseField>

--- a/api-reference/person/find.mdx
+++ b/api-reference/person/find.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Find Persons"
-api: "POST https://api.travtus.com/persons/find?after-id={after-id}/"
+api: "POST https://api.travtus.com/persons/find/"
 description: "This endpoint allows users to find a list of persons based on multiple person attributes."
 ---
 
@@ -12,14 +12,6 @@ Optionally, you can also pass in a list of group IDs to filter the returned pers
 
 <ParamField header="Authorization" type="string" default="none" required>
   The authentication token for your request
-</ParamField>
-
-### Query
-
-<ParamField query="after-id" type="string" default="1">
-  The API returns a maximum of 10 records per call.
-  
-  You can use this query parameter to load the next set of records by passing in the value returned in the response, under `last_id`.
 </ParamField>
 
 ### Body
@@ -50,6 +42,12 @@ Optionally, you can also pass in a list of group IDs to filter the returned pers
 
 <ParamField body="groups" type="[string]" default="none" required>
   The list of group IDs for filtering the retrieved list.
+</ParamField>
+
+<ParamField body="after-id" type="string" default="1">
+  The API returns a maximum of 100 records per call.
+
+  You can use this parameter to load the next set of records by passing in the value returned in the response, under `last_id`.
 </ParamField>
 
 ### Response
@@ -87,7 +85,7 @@ Optionally, you can also pass in a list of group IDs to filter the returned pers
 <ResponseField name="last_id" type="integer">
   The last id in the set of results returned for this API call.
 
-  You can use this value in the `after-id` query parameter to load the next set of results.
+  You can use this value in the `after-id` parameter to load the next set of results.
 
   If there are no more results to load, this value will be -1.
 
@@ -133,12 +131,13 @@ Returned if no person records can be found matching the provided information.
 <RequestExample>
 
 ```bash Example Request
-curl --location --request POST 'https://api.travtus.com/persons/find?after-id=1/' \
+curl --location --request POST 'https://api.travtus.com/persons/find/' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: bearer <token>'
 --data-raw '{
   "phone_number": "01234567890",
-  "groups": ["group-1"]
+  "groups": ["group-1"],
+  "after-id": 1
 }
 ```
 

--- a/api-reference/unit/find.mdx
+++ b/api-reference/unit/find.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Find Units"
-api: "POST https://api.travtus.com/units/find?after-id={after-id}/"
+api: "POST https://api.travtus.com/units/find/"
 description: "This endpoint finds units with the list of body attributes passed to it."
 ---
 
@@ -12,14 +12,6 @@ Optionally, you can also pass in a list of group IDs to filter the returned unit
 
 <ParamField header="Authorization" type="string" default="none" required>
   The authentication token for your request.
-</ParamField>
-
-### Query
-
-<ParamField query="after-id" type="string" default="1">
-  The API returns a maximum of 10 records per call.
-  
-  You can use this query parameter to load the next set of records by passing in the value returned in the response, under `last_id`.
 </ParamField>
 
 ### Body
@@ -91,12 +83,18 @@ Optionally, you can also pass in a list of group IDs to filter the returned unit
   </Expandable>
 </ParamField>
 
+<ParamField body="after-id" type="string" default="1">
+  The API returns a maximum of 100 records per call.
+  
+  You can use this parameter to load the next set of records by passing in the value returned in the response, under `last_id`.
+</ParamField>
+
 ### Response
 
 <ResponseField name="last_id" type="integer">
   The last id in the set of results returned for this API call.
 
-  You can use this value in the `after-id` query parameter to load the next set of results.
+  You can use this value in the `after-id` parameter to load the next set of results.
 
   If there are no more results to load, this value will be -1.
 </ResponseField>
@@ -213,14 +211,15 @@ Returned if no unit records can be found matching the provided information.
 <RequestExample>
 
 ```bash Example Request
-curl --location --request POST 'https://api.travtus.com/units/find?after-id=1/' \
+curl --location --request POST 'https://api.travtus.com/units/find/' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: bearer <token>' \
 --data-raw '{
   "address": {
     "country": "United States"
   },
-  "groups": ["group-1"]
+  "groups": ["group-1"],
+  "after-id": 1
 }
 ```
 


### PR DESCRIPTION
## What is the goal of this PR?
The API now uses body parameters for the after-id pagination parameter as well as the inactive date for listings.