### PR TITLE
Updates to portfolio functionality and to vacancy find endpoint

### DIFF
--- a/api-reference/lease/find-leases-for-tenant.mdx
+++ b/api-reference/lease/find-leases-for-tenant.mdx
@@ -18,6 +18,12 @@ Active leases have an end date in the future and a start date in the past relati
 
 All date fields included in the body parameters need to be specified as [ISO8601-formatted date strings](https://en.wikipedia.org/wiki/ISO_8601).
 
+If finding tenants via their external referance, you must provide the group the tenant belongs to.
+
+The group can be specified via either the `group_id` or `group_external_ref` attribute.
+
+Do not provide both, as this will result in the request failing.
+
 ### Example use cases
 This endpoint allows you to find leases for a specific tenant.
 
@@ -53,10 +59,16 @@ You can retrieve all leases for a tenant given their phone number or email addre
   Determines whether only active leases are retrieved for the provided tenant.
 </ParamField>
 
-<ParamField body="group" type="string" default="none">
-  The group ID the tenant belongs to.
+<ParamField body="group_id" type="string" default="none">
+  The id of the group the tenant belongs to.
 
-  This is needed if passing the external_ref as the tenant identifier.
+  This attribute or the group_external_ref one is needed if using the external_ref for the tenant.
+</ParamField>
+
+<ParamField body="group_external_ref" type="string" default="none">
+  The external reference of the group the tenant belongs to.
+
+  This attribute or the group_id one is needed if using the external_ref for the tenant.
 </ParamField>
 
 <ParamField body="after-id" type="string" default="1">
@@ -212,6 +224,30 @@ Returned if none of the tenant parameters are provided in the request body
    "error": {
     "type": "no_tenant_information",
     "message": "You need to provide at least one of identifier, external_ref AND group, email_address, or phone_number in the request body."
+  }
+}
+```
+
+Status Code - 400
+
+Returned if both of the group_id and group_external_ref attributes are provided
+```json Both group id and external ref provided for the find leases for tenant operation
+{
+   "error": {
+    "type": "both_group_identifiers_provided",
+    "message": "You have provided both the group id and group external reference for the find leases for tenant operation. Please only provide one of the two."
+  }
+}
+```
+
+Status Code - 400
+
+Returned if no group_id or group_external_ref is provdided when identifying a tenant via an external_ref
+```json No group id or group external ref provided for tenant external reference.
+{
+   "error": {
+    "type": "both_group_identifiers_provided",
+    "message": "You have not a group id or group external reference when identifying a tenant via their external reference. Please provide one of the two."
   }
 }
 ```

--- a/api-reference/lease/find-tenants.mdx
+++ b/api-reference/lease/find-tenants.mdx
@@ -17,6 +17,12 @@ You can retrieve tenants for leases belonging specific group via the group's ID.
 
 You can retrieve tenants with a lease at a particular address, with the possibility of narrowing or broadening the search by providing more or less address data.
 
+You can provide either a group id through the `group_id` parameter or a group external reference through the `group_external_ref` attribute to filter the list of retrieved tenants down.
+
+Do not provide both, as this will result in the request failing.
+
+If no group_id or group_external_ref are specified in the request body, the authenticated user will retrieve tenant records for all groups they have access to.
+
 ### Header
 
 <ParamField header="Authorization" type="string" default="none" required>
@@ -37,8 +43,12 @@ You can retrieve tenants with a lease at a particular address, with the possibil
   The upper boundary for the lease's tenants' move in date.
 </ParamField>
 
-<ParamField body="group" type="string" default="none">
+<ParamField body="group_id" type="string" default="none">
   The id of the group the lease and tenants belong to.
+</ParamField>
+
+<ParamField body="group_external_ref" type="string" default="none">
+  The external reference of the group the lease and tenants belong to.
 </ParamField>
 
 <ParamField body="address" type="object" default="none">
@@ -151,6 +161,18 @@ Status Code - 401
    "error": {
     "type": "invalid_authorization",
     "message": "The bearer token you have provided in the 'Authorization' header is invalid."
+  }
+}
+```
+
+Status Code - 400
+
+Returned if both a group id and group_external_ref are provided
+```json Both group id and external ref provided for the tenant find operation
+{
+   "error": {
+    "type": "both_group_identifiers_provided",
+    "message": "You have provided both a group id and group external reference for the find tenant operation. Please only provide one of the two."
   }
 }
 ```

--- a/api-reference/lease/find.mdx
+++ b/api-reference/lease/find.mdx
@@ -17,6 +17,12 @@ You can retrieve all leases for a specific unit by passing the internal ID or th
 
 You can retrieve leases for a given address, with the possibility of narrowing or broadening the search by providing more or less address data.
 
+You can provide either group ids through the `group_ids` parameter or group external references through the `group_external_refs` attribute to filter the list of retrieved leases down.
+
+Do not provide both, as this will result in the request failing.
+
+If no group_ids or group_external_refs are specified in the request body, the authenticated user will retrieve lease records for all groups they have access to.
+
 ### Header
 
 <ParamField header="Authorization" type="string" default="none" required>
@@ -41,8 +47,12 @@ You can retrieve leases for a given address, with the possibility of narrowing o
   The move in date of the leases to be retrieved.
 </ParamField>
 
-<ParamField body="groups" type="[string]" default="none">
-  The id of groups to retrieve leases for.
+<ParamField header="group_ids" type="[string]" default="none">
+  A list of group ids to retrieve leases for.
+</ParamField>
+
+<ParamField header="groups_external_refs" type="[string]" default="none">
+  A list of group external refs to retrieve leases for.
 </ParamField>
 
 <ParamField body="unit_external_refs" type="[string]" default="none">
@@ -229,6 +239,18 @@ Status Code - 401
    "error": {
     "type": "invalid_authorization",
     "message": "The bearer token you have provided in the 'Authorization' header is invalid."
+  }
+}
+```
+
+Status Code - 400
+
+Returned if both a group id and group_external_ref are provided
+```json Both group id and external ref provided for the tenant find operation
+{
+   "error": {
+    "type": "both_group_identifiers_provided",
+    "message": "You have provided both a group id and group external reference for the find leases operation. Please only provide one of the two."
   }
 }
 ```

--- a/api-reference/listing/find.mdx
+++ b/api-reference/listing/find.mdx
@@ -4,11 +4,15 @@ api: "POST https://api.travtus.com/listings/find/"
 description: "This endpoint finds listings for the provided parameters."
 ---
 
-If no group is passed in the request body, listings for all groups the authenticated user has access to will be retrieved.
-
 All date fields included in the body parameters need to be specified as [ISO8601-formatted date strings](https://en.wikipedia.org/wiki/ISO_8601).
 
 This endpoint only returns vacancies that are active.
+
+You can provide either a group id through the `group_id` parameter or a group external reference through the `group_external_ref` attribute to filter the list of retrieved listings down.
+
+Do not provide both, as this will result in the request failing.
+
+If no group_id or group_external_ref are specified in the request body, the authenticated user will retrieve listing records for all groups they have access to.
 
 ### Header
 
@@ -18,8 +22,16 @@ This endpoint only returns vacancies that are active.
 
 ### Body
 
-<ParamField body="group" type="string" default="none">
+<ParamField body="group_id" type="string" default="none">
   The id of the group of the listings to retrieve.
+</ParamField>
+
+<ParamField body="group_external_ref" type="string" default="none">
+  The external reference of the group of the listings to retrieve.
+</ParamField>
+
+<ParamField body="external_ref" type="string" default="none">
+  The external identifier of the listings to retrieve.
 </ParamField>
 
 <ParamField body="identifier" type="string" default="none">
@@ -204,6 +216,18 @@ Status Code - 401
 }
 ```
 
+Status Code - 400
+
+Returned if both a group id and group_external_ref are provided
+```json Both group id and external ref provided for the listing find operation
+{
+   "error": {
+    "type": "both_group_identifiers_provided",
+    "message": "You have provided both a group id and group external reference for the find listings operation. Please only provide one of the two."
+  }
+}
+```
+
 Status Code - 404
 
 Returned if no listing records can be found matching the provided information.
@@ -223,7 +247,7 @@ curl --location --request POST 'https://api.travtus.com/listings/find/' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: bearer <token>' \
 --data-raw '{
-  "group": "group-id-1"
+  "group_id": "group-id-1"
 }
 ```
 
@@ -237,6 +261,7 @@ curl --location --request POST 'https://api.travtus.com/listings/find/' \
   "listings": [
     {
       "identifier": "listing-1",
+      "external_ref": "listing-external-ref-1",
       "amenities": [
         "Swimming Pool",
         "Gym"

--- a/api-reference/listing/sync.mdx
+++ b/api-reference/listing/sync.mdx
@@ -14,6 +14,10 @@ Listings for the provided group that are not included in the request body will b
 
 If there are no listings passed in the request body, all listings for the provided porfolio will be deleted.
 
+You must provide either a group id via the `group_id` parameter or a group external reference via the `group_external_ref` attribute.
+
+If both are provided, the request will not be successful.
+
 ### Header
 
 <ParamField header="Authorization" type="string" default="none" required>
@@ -243,7 +247,7 @@ Status Code - 401
 
 Status Code - 400
 
-Returned if no group id or group_external_ref are provided
+Returned if no group_id or group_external_ref is provided
 ```json No group provided for the listing synchronise operation
 {
    "error": {
@@ -260,7 +264,7 @@ Returned if both a group id or group_external_ref are provided
 {
    "error": {
     "type": "both_group_identifiers_provided",
-    "message": "You have provided both a group id and group external reference for the listing synchronise operation. Please only provide one of the two."
+    "message": "You have provided both a group id and group external reference for the listings synchronise operation. Please only provide one of the two."
   }
 }
 ```

--- a/api-reference/person/find.mdx
+++ b/api-reference/person/find.mdx
@@ -6,7 +6,11 @@ description: "This endpoint allows users to find a list of persons based on mult
 
 You need to provide exact matches in the body of the request for the attributes of the persons you are looking for.
 
-Optionally, you can also pass in a list of group IDs to filter the returned persons down.
+You can provide either a list of group ids through the `group_ids` parameter or a list of group external references through the `groups_external_refs` attribute to filter the list of retrieved persons down.
+
+Do not provide both, as this will result in the request failing.
+
+If no group_ids or group_external_refs are specified in the request body, the authenticated user will retrieve person records for all groups they have access to.
 
 ### Header
 
@@ -40,8 +44,12 @@ Optionally, you can also pass in a list of group IDs to filter the returned pers
   Internal identifier of the persons you want to retrieve.
 </ParamField>
 
-<ParamField body="groups" type="[string]" default="none" required>
-  The list of group IDs for filtering the retrieved list.
+<ParamField body="group_ids" type="[string]" default="none">
+  The list of group ids for filtering the retrieved list.
+</ParamField>
+
+<ParamField body="groups_external_refs" type="[string]" default="none">
+  The list of group external references for filtering the retrieved list.
 </ParamField>
 
 <ParamField body="after-id" type="string" default="1">
@@ -126,6 +134,19 @@ Status Code - 401
 }
 ```
 
+Status Code - 400
+
+Returned if both of the group_ids and groups_external_refs attributes are provided
+```json Both group ids and external refs provided for the person find operation
+{
+   "error": {
+    "type": "both_group_identifiers_provided",
+    "message": "You have provided both group ids and group external references for the find persons operation. Please only provide one of the two."
+  }
+}
+```
+
+
 Status Code - 404
 
 Returned if no person records can be found matching the provided information.
@@ -146,7 +167,7 @@ curl --location --request POST 'https://api.travtus.com/persons/find/' \
 --header 'Authorization: bearer <token>'
 --data-raw '{
   "phone_number": "01234567890",
-  "groups": ["group-1"],
+  "groups_external_refs": ["group-1"],
   "after-id": 1
 }
 ```

--- a/api-reference/person/post-multiple.mdx
+++ b/api-reference/person/post-multiple.mdx
@@ -12,9 +12,13 @@ If a match is found, the existing person record will be updated with the informa
 
 If no match is found, a new person record will be created and scoped to the provided groups.
 
-If no groups are provided, any updated or created person records will be scoped to all groups.
+If no groups are provided, any updated or created person records will be scoped to all groups the logged in user has access to.
 
 If you do not have access to one of the groups you have provided, the endpoint will not attempt to match the person record against records in that group and any newly created persons will not be assigned to the group.
+
+You can provide either a group id via the `group_id` parameter or a group external reference via the `group_external_ref` attribute.
+
+If both are provided for any of the person records in ther request body, the request will not be successful.
 
 Matching of the person records is done in the following order:
   1. By external reference. A person record will be updated if the provided `external_ref` in the request body is an exact match.
@@ -79,8 +83,14 @@ would not be accepted, as it fails to provide a value for an attribute from the 
       The phone number of the persons you want to create or update.
     </ParamField>
 
-    <ParamField header="groups" type="[string]" default="none">
-      A list of group IDs to be used when creating or updating the person record.
+    <ParamField header="group_ids" type="[string]" default="none">
+      A list of group ids to be used when creating or updating the person record.
+
+      The groups will be used for matching existing person records and for scoping newly created ones.
+    </ParamField>
+
+    <ParamField header="groups_external_refs" type="[string]" default="none">
+      A list of group external refs to be used when creating or updating the person record.
 
       The groups will be used for matching existing person records and for scoping newly created ones.
     </ParamField>
@@ -166,6 +176,18 @@ Status Code - 401
 }
 ```
 
+Status Code - 400
+
+Returned if both of the group_ids and groups_external_refs attributes are provided for a person
+```json Both group ids and external refs provided for the person find operation
+{
+   "error": {
+    "type": "both_group_identifiers_provided",
+    "message": "You have provided both group ids and group external references for a person in your request body. Please only provide one of the two."
+  }
+}
+```
+
 <RequestExample>
 
 ```bash Example Request
@@ -180,7 +202,7 @@ curl --location --request POST 'https://api.travtus.com/persons/multiple/' \
         "last_name": "Person 1",
         "external_ref": "id-1",
         "phone_number": "01234567890",
-        "groups": "['group-1', 'group-2']"
+        "group_ids": "['group-1', 'group-2']"
       },
       {
         "email_address": "test.person.2@travtus.com",
@@ -188,11 +210,11 @@ curl --location --request POST 'https://api.travtus.com/persons/multiple/' \
         "last_name": "Person 2",
         "external_ref": "id-2",
         "phone_number": "01234567891",
-        "groups": "['group-1']"
+        "group_ids": "['group-1']"
       },
       {
          "first_name": "Test insuficient info",
-         "groups": "['group-1']"
+         "groups_external_refs": "['group-external-ref-1']"
       }
     ]
 }'
@@ -212,7 +234,6 @@ curl --location --request POST 'https://api.travtus.com/persons/multiple/' \
         "last_name": "Person 1",
         "external_ref": "id-1",
         "phone_number": "01234567890",
-        "groups": "['group-1', 'group-2']",
         "success": true,
         "failure_reason": ""
       },
@@ -223,7 +244,6 @@ curl --location --request POST 'https://api.travtus.com/persons/multiple/' \
         "last_name": "Person 2",
         "external_ref": "id-2",
         "phone_number": "01234567891",
-        "groups": "['group-1']",
         "success": true,
         "failure_reason": ""
       },

--- a/api-reference/unit/find.mdx
+++ b/api-reference/unit/find.mdx
@@ -6,7 +6,11 @@ description: "This endpoint finds units with the list of body attributes passed 
 
 You need to provide exact matches in the body of the request for the attributes of the units you are looking for.
 
-Optionally, you can also pass in a list of group IDs to filter the returned units down.
+You can provide either a list of group ids through the `group_ids` parameter or a list of group external references through the `groups_external_refs` attribute to filter the list of retrieved units down.
+
+Do not provide both, as this will result in the request failing.
+
+If no group_ids or group_external_refs are specified in the request body, the authenticated user will retrieve unit records for all groups they have access to.
 
 ### Header
 
@@ -16,8 +20,12 @@ Optionally, you can also pass in a list of group IDs to filter the returned unit
 
 ### Body
 
-<ParamField body="groups" type="[string]" default="none">
-  The list of group IDs you want to filter the returned units down to.
+<ParamField body="group_ids" type="[string]" default="none">
+  The list of group ids for filtering the retrieved list.
+</ParamField>
+
+<ParamField body="groups_external_refs" type="[string]" default="none">
+  The list of group external references for filtering the retrieved list.
 </ParamField>
 
 <ParamField body="external_ref" type="string" default="none">
@@ -204,6 +212,18 @@ Status Code - 401
 }
 ```
 
+Status Code - 400
+
+Returned if both of the group_ids and groups_external_refs attributes are provided
+```json Both group ids and external refs provided for the unit find operation
+{
+   "error": {
+    "type": "both_group_identifiers_provided",
+    "message": "You have provided both group ids and group external references for the find units operation. Please only provide one of the two."
+  }
+}
+```
+
 Status Code - 404
 
 Returned if no unit records can be found matching the provided information.
@@ -227,7 +247,7 @@ curl --location --request POST 'https://api.travtus.com/units/find/' \
   "address": {
     "country": "United States"
   },
-  "groups": ["group-1"],
+  "group_ids": ["group-1"],
   "after-id": 1
 }
 ```

--- a/api-reference/unit/post-multiple.mdx
+++ b/api-reference/unit/post-multiple.mdx
@@ -6,7 +6,11 @@ description: "This endpoint creates or updates multiple units."
 
 A group must be provided for updating or creating the units.
 
-If a group id is not provided for the mulit-create/update endpoint, the operation will fail.
+You can provide either a group id through the `group_id` parameter or a group external reference through the `group_external_ref` attribute.
+
+Do not provide both, as this will result in the request failing.
+
+If no group id or group external reference is provided, the operation will fail.
 
 This endpoint firstly attempts to match the provided units data with existing units via the unit's identifier body parameter, in order to update an existing entry.
 
@@ -20,8 +24,12 @@ If a unit is not found via the identifier or the identifier parameter is not set
 
 ### Body
 
-<ParamField body="group" type="string" deafault="none" required>
-  The ID of the group you want to create or update the units against.
+<ParamField body="group_id" type="string" default="none">
+  The id of the group you want to create or update the units for.
+</ParamField>
+
+<ParamField body="group_external_ref" type="string" default="none">
+  The external reference of the group you want to create or update the units for.
 </ParamField>
 
 <ParamField body="units" type="[object]" default="none" required>
@@ -237,15 +245,27 @@ Status Code - 401
 
 Status Code - 400
 
-Returned if no group ID is passed in the body.
-```json No group ID supplied
+Returned if no group id or external reference is passed in the body.
+```json No group id or external reference supplied
 {
    "error": {
-    "type": "no_group_id",
-    "message": "You must provide a group ID in the request body."
+    "type": "no_group",
+    "message": "You must either provide a group id or group external reference in the request body."
   }
 }
 
+```
+
+Status Code - 400
+
+Returned if both a group id and group_external_ref are provided
+```json Both group id and external ref provided for the unit post-multiple operation
+{
+   "error": {
+    "type": "both_group_identifiers_provided",
+    "message": "You have provided both a group id and group external reference for the create/update units operation. Please only provide one of the two."
+  }
+}
 ```
 
 
@@ -282,7 +302,7 @@ curl --location --request "POST 'https://api.travtus.com/units/multiple/' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: bearer <token>' \
 --data-raw '{
-    "group": "group-id-1",
+    "group_id": "group-id-1",
     "units": [
       {
         "identifier": "unit-id-1",


### PR DESCRIPTION
## What is the goal of this PR?

We are allowing users to pass in their portfolio external references to scope requests instead of only supporting internal portfolio IDs.

Only supporting internal portfolio IDs would mean that API users would have to maintain a mapping between their own identifiers for their corresponding portfolio entity and our own internal portfolio IDs. We will be doing that for them in the Travtus API as we already have the information that we need and it would take minimal development effort to implement this.

Modify the find vacancy endpoint to reflect the fact that vacancies now have external references.