### PR TITLE
Add errors to listing endpoints and fix bugs with request examples on several endpoints

### DIFF
--- a/api-reference/lease/find-leases-for-tenant.mdx
+++ b/api-reference/lease/find-leases-for-tenant.mdx
@@ -18,6 +18,8 @@ Active leases have an end date in the future and a start date in the past relati
 
 All date fields included in the body parameters need to be specified as [ISO8601-formatted date strings](https://en.wikipedia.org/wiki/ISO_8601).
 
+Date fields should follow a "YYYY-MM-DD" format.
+
 If finding tenants via their external referance, you must provide the group the tenant belongs to.
 
 The group can be specified via either the `group_id` or `group_external_ref` attribute.

--- a/api-reference/lease/find-tenants.mdx
+++ b/api-reference/lease/find-tenants.mdx
@@ -6,6 +6,8 @@ description: "This endpoint returns a list of tenants filtered with the specifie
 
 All date fields included in the body parameters need to be specified as [ISO8601-formatted date strings](https://en.wikipedia.org/wiki/ISO_8601).
 
+Date fields should follow a "YYYY-MM-DD" format.
+
 ### Example use cases
 This endpoint allows you to find tenants based on lease parameters.
 

--- a/api-reference/lease/find.mdx
+++ b/api-reference/lease/find.mdx
@@ -8,6 +8,8 @@ You need to provide exact matches in the body of the request for the attributes 
 
 All date fields included in the body parameters need to be specified as [ISO8601-formatted date strings](https://en.wikipedia.org/wiki/ISO_8601).
 
+Date fields should follow a "YYYY-MM-DD" format.
+
 ### Example use cases
 This endpoint allows you to find leases based on a number of parameters.
 

--- a/api-reference/listing/delete.mdx
+++ b/api-reference/listing/delete.mdx
@@ -87,12 +87,12 @@ Returned if the currently authenticated user does not have permission to delete 
 <RequestExample>
 
 ```bash Example Request
-curl --location --request "DELETE 'https://api.travtus.com/listings/listing-id-1/' \
+curl --location --request "DELETE 'https://api.travtus.com/listings/listing-id-1/'" \
 --header 'Content-Type: application/json' \
 --header 'Authorization: bearer <token>' \
 --data-raw '{
   "inactive_date": "2012-01-23"
-}
+}'
 ```
 
 </RequestExample>

--- a/api-reference/listing/delete.mdx
+++ b/api-reference/listing/delete.mdx
@@ -8,6 +8,8 @@ Allows for a listing to be immediately deleted or to be scheduled for deletion.
 
 All date fields included in the body parameters need to be specified as [ISO8601-formatted date strings](https://en.wikipedia.org/wiki/ISO_8601).
 
+Date fields should follow a "YYYY-MM-DD" format.
+
 ### Header
 
 <ParamField header="Authorization" type="string" default="none" required>

--- a/api-reference/listing/find.mdx
+++ b/api-reference/listing/find.mdx
@@ -12,7 +12,7 @@ You can provide either a group id through the `group_id` parameter or a group ex
 
 Do not provide both, as this will result in the request failing.
 
-If no group_id or group_external_ref are specified in the request body, the authenticated user will retrieve listing records for all groups they have access to.
+You must provide either a group_id or group_external_ref, otherwise the request will fail.
 
 ### Header
 
@@ -60,6 +60,10 @@ If no group_id or group_external_ref are specified in the request body, the auth
       The internal identifier for the retrieved listing.
     </ResponseField>
 
+    <ResponseField name="external_ref" type="string">
+      The external identifier for the retrieved listing.
+    </ResponseField>
+
     <ResponseField name="amenities" type="[string]">
       A list of amenities available in the listing's building.
     </ResponseField>
@@ -70,24 +74,6 @@ If no group_id or group_external_ref are specified in the request body, the auth
 
     <ResponseField name="finish" type="string">
       The tier of finish for the listing.
-    </ResponseField>
-
-    <ResponseField name="bathrooms" type="[object]">
-      A list of bathroom characteristics for each bathroom in the listing.
-      <Expandable title="bathroom">
-        <ResponseField name="identifier" type="boolean">
-          The internal identifier for the bathroom.
-        </ResponseField>
-        <ResponseField name="has_shower_or_bath" type="boolean">
-          Does the bathroom have either a shower or a bath?
-        </ResponseField>
-        <ResponseField name="has_sink" type="boolean">
-          Does the bathroom have a sink?
-        </ResponseField>
-        <ResponseField name="has_toilet" type="boolean">
-          Does the bathroom have a toilet?
-        </ResponseField>
-      </Expandable>
     </ResponseField>
 
     <ResponseField name="bedrooms" type="integer">
@@ -124,28 +110,6 @@ If no group_id or group_external_ref are specified in the request body, the auth
 
     <ResponseField name="is_furnished" type="boolean">
       Whether the listing is furnished or not.
-    </ResponseField>
-
-    <ResponseField name="lease_terms" type="object">
-      A list of the terms for the retrieved lease.
-
-      <Expandable title ="lease term">
-        <ResponseField name="identifier" type="string">
-          The identifier of the retrieved lease term.
-        </ResponseField>
-        <ResponseField name="group" type="string">
-          The group the lease term belongs to.
-        </ResponseField>
-        <ResponseField name="deposit" type="float">
-          The deposit amount for the lease term.
-        </ResponseField>
-        <ResponseField name="length_in_months" type="integer">
-          The length in months for the lease term.
-        </ResponseField>
-        <ResponseField name="rent" type="float">
-          The rent for the lease term.
-        </ResponseField>
-      </Expandable>
     </ResponseField>
 
     <ResponseField name="move_in_date" type="date">
@@ -228,6 +192,30 @@ Returned if both a group id and group_external_ref are provided
 }
 ```
 
+Status Code - 400
+
+Returned if neither a group id nor a group_external_ref are provided
+```json Neither group id nor external ref provided for the listing find operation
+{
+   "error": {
+    "type": "no_group_identifier_provided",
+    "message": "You have not provided either a group id or a group external reference for the find listings operation. Please provide one of the two."
+  }
+}
+```
+
+Status Code - 401
+
+Returned if the user does not have access to the provided group
+```json Authenticated user does not have access to the requested group
+{
+   "error": {
+    "type": "no_access_to_group",
+    "message": "You do not have access to view information on the group you have provided in the request."
+  }
+}
+```
+
 Status Code - 404
 
 Returned if no listing records can be found matching the provided information.
@@ -248,7 +236,7 @@ curl --location --request POST 'https://api.travtus.com/listings/find/' \
 --header 'Authorization: bearer <token>' \
 --data-raw '{
   "group_id": "group-id-1"
-}
+}'
 ```
 
 </RequestExample>
@@ -270,20 +258,6 @@ curl --location --request POST 'https://api.travtus.com/listings/find/' \
         "Floor heating"
       ],
       "finish": "gold",
-      "bathrooms": [
-        {
-          "identifier": "listing-1-bathroom-1",
-          "has_shower_or_bath": true,
-          "has_sink": true,
-          "has_toilet": true
-        },
-        {
-          "identifier": "listing-1-bathroom-2",
-          "has_shower_or_bath": false,
-          "has_sink": true,
-          "has_toilet": true
-        }
-      ],
       "bedrooms": 2,
       "deposit_for_12_month_lease": 1400.00,
       "description": "A beautiful apartment in the heart of the city.",
@@ -296,15 +270,6 @@ curl --location --request POST 'https://api.travtus.com/listings/find/' \
       ],
       "is_flex": false,
       "is_furnished": true,
-      "lease_terms": [
-        {
-          "identifier": "listing-1-lease-term-1",
-          "group": "group-id-1",
-          "deposit": 1400.00,
-          "length_in_months": 12,
-          "rent": 700.00
-        }
-      ],
       "move_in_date": "2023-01-17",
       "rent_for_12_month_lease": 700.00,
       "sqft": 40,
@@ -316,6 +281,7 @@ curl --location --request POST 'https://api.travtus.com/listings/find/' \
     },
     {
       "identifier": "listing-2",
+      "external_ref": "listing-external-ref-2",
       "amenities": [
         "Swimming Pool",
         "Gym"
@@ -324,14 +290,6 @@ curl --location --request POST 'https://api.travtus.com/listings/find/' \
         "Dishwasher"
       ],
       "finish": "Silver",
-      "bathrooms": [
-        {
-          "identifier": "listing-2-bathroom-1",
-          "has_shower_or_bath": true,
-          "has_sink": true,
-          "has_toilet": true
-        }
-      ],
       "bedrooms": 1,
       "deposit_for_12_month_lease": 1200.00,
       "description": "A beautiful unfurnished studio apartment in the heart of the city.",
@@ -344,15 +302,6 @@ curl --location --request POST 'https://api.travtus.com/listings/find/' \
       ],
       "is_flex": false,
       "is_furnished": false,
-      "lease_terms": [
-        {
-          "identifier": "listing-2-lease-term-1",
-          "group": "group-id-1",
-          "deposit": 1200.00,
-          "length_in_months": 12,
-          "rent": 600.00
-        }
-      ],
       "move_in_date": "2023-01-17",
       "rent_for_12_month_lease": 600.00,
       "sqft": 35,

--- a/api-reference/listing/find.mdx
+++ b/api-reference/listing/find.mdx
@@ -6,6 +6,8 @@ description: "This endpoint finds listings for the provided parameters."
 
 All date fields included in the body parameters need to be specified as [ISO8601-formatted date strings](https://en.wikipedia.org/wiki/ISO_8601).
 
+Date fields should follow a "YYYY-MM-DD" format.
+
 This endpoint only returns vacancies that are active.
 
 You can provide either a group id through the `group_id` parameter or a group external reference through the `group_external_ref` attribute to filter the list of retrieved listings down.

--- a/api-reference/listing/post.mdx
+++ b/api-reference/listing/post.mdx
@@ -424,7 +424,7 @@ curl --location --request POST 'https://api.travtus.com/listings/' \
   "unit_number": "1",
   "unit_type": "apartment",
   "listing_url": "www.listings.com/listing-1"
-}
+}'
 ```
 
 </RequestExample>

--- a/api-reference/listing/sync.mdx
+++ b/api-reference/listing/sync.mdx
@@ -247,36 +247,24 @@ Status Code - 401
 
 Status Code - 400
 
+Returned if both a group id and group_external_ref are provided
+```json Both group id and external ref provided for the listing synchronise operation
+{
+   "error": {
+    "type": "both_group_identifiers_provided",
+    "message": "You have provided both a group id and group external reference for the synchronise listings operation. Please only provide one of the two."
+  }
+}
+```
+
+Status Code - 400
+
 Returned if no group_id or group_external_ref is provided
 ```json No group provided for the listing synchronise operation
 {
    "error": {
     "type": "no_group_provided",
-    "message": "You have not provided a group for the listing synchronise operation."
-  }
-}
-```
-
-Status Code - 400
-
-Returned if both a group id or group_external_ref are provided
-```json Both group id and external ref provided for the listing synchronise operation
-{
-   "error": {
-    "type": "both_group_identifiers_provided",
-    "message": "You have provided both a group id and group external reference for the listings synchronise operation. Please only provide one of the two."
-  }
-}
-```
-
-Status Code - 400
-
-Returned if both a listing identifier and external_ref are provided
-```json Both group id and external ref provided for the listing synchronise operation
-{
-   "error": {
-    "type": "both_identifier_and_external_ref_provided",
-    "message": "You have provided both an identifier and an external_ref for a listing. Please only provide one of the two."
+    "message": "You have not provided either a group id or a group external reference for the synchronise listings operation. Please provide one of the two."
   }
 }
 ```
@@ -289,6 +277,18 @@ Returned if both the number_of_bathrooms and the bathrooms attributes are popula
    "error": {
     "type": "both_bathroom_attributes_provided",
     "message": "You have provided both a number_of_bathrooms and a bathrooms attribute. Please only provide one of the two."
+  }
+}
+```
+
+Status Code - 401
+
+Returned if the user does not have access to the provided group
+```json Authenticated user does not have access to the requested group
+{
+   "error": {
+    "type": "no_access_to_group",
+    "message": "You do not have access to the synchronise listings operation for the group you have provided in the request."
   }
 }
 ```
@@ -361,7 +361,7 @@ curl --location --request POST 'https://api.travtus.com/listings/' \
       "listing_url": "www.listings.com/listing-1"
     }
   ]
-}
+}'
 ```
 
 </RequestExample>

--- a/api-reference/listing/sync.mdx
+++ b/api-reference/listing/sync.mdx
@@ -18,6 +18,10 @@ You must provide either a group id via the `group_id` parameter or a group exter
 
 If both are provided, the request will not be successful.
 
+All date fields included in the body parameters need to be specified as [ISO8601-formatted date strings](https://en.wikipedia.org/wiki/ISO_8601).
+
+Date fields should follow a "YYYY-MM-DD" format.
+
 ### Header
 
 <ParamField header="Authorization" type="string" default="none" required>
@@ -55,7 +59,7 @@ If both are provided, the request will not be successful.
 
       This is a unique identifier we have assigned to a listing within our system, which you can retrieve via our find endpoint.
     </ParamField>
-    <ParamField body="external_reference" type="string" default="none">
+    <ParamField body="external_reference" type="string" default="none" required>
       The external reference of the listing you want to update or create.
 
       This is a unique external reference for a listing that you may set when creating a listing.
@@ -289,6 +293,90 @@ Returned if the user does not have access to the provided group
    "error": {
     "type": "no_access_to_group",
     "message": "You do not have access to the synchronise listings operation for the group you have provided in the request."
+  }
+}
+```
+
+Status Code - 401
+
+Returned if no external reference is provided for one of the listings
+```json No external reference provided for a listing
+{
+   "error": {
+    "type": "no_external_reference",
+    "message": "You have not provided an external reference for a listing. Please provide one."
+  }
+}
+```
+
+Status Code - 401
+
+Returned if any of the dates provided on a listing are in an incorrect format
+```json Date on listing is in an incorrect format
+{
+   "error": {
+    "type": "date_format_invalid",
+    "message": "You have provided a date in an invalid format. All dates must be provided in the YYYY-MM-DD format."
+  }
+}
+```
+
+Status Code - 401
+
+Returned if any of the listings are missing a unit_type field
+```json Vacancy is missing unit_type
+{
+   "error": {
+    "type": "missing_unit_type",
+    "message": "You are missing the required unit_type field for a listing. Please add the field to your listing."
+  }
+}
+```
+
+Status Code - 401
+
+Returned if any of the listings are missing the listing_url field
+```json Listing is missing listing_url
+{
+   "error": {
+    "type": "missing_listing_url",
+    "message": "You are missing the required listing_url field for a listing. Please add the field to your listing."
+  }
+}
+```
+
+Status Code - 401
+
+Returned if any of the listings have an invalid unit_type
+```json Listing has invalid unit_type
+{
+   "error": {
+    "type": "invalid_unit_type",
+    "message": "Invalid value for unit_type field on a listing. Please use either \"apartment\" or \"studio_apartment\"."
+  }
+}
+```
+
+Status Code - 401
+
+Returned if neither of the bathroom attributes are provided
+```json Listing has neither of the bathroom attributes provided
+{
+   "error": {
+    "type": "no_bathroom_attributes_provided",
+    "message": "You have provided neither the number_of_bathrooms or the bathrooms attribute. Please provide one of the two."
+  }
+}
+```
+
+Status Code - 401
+
+Returned if the bathroom attribute is not provided and the number of bathrooms is less than 1
+```json Listing does not have a bathroom attribute and the number of bathrooms is less than 1
+{
+   "error": {
+    "type": "invalid_number_of_bathrooms",
+    "message": "You have not provided a bathroom attribute and set the number_of_bathrooms to less than 1. Please provide the bathrooms attribute or set the number_of_bathrooms to a number greater than 0."
   }
 }
 ```

--- a/api-reference/person/find.mdx
+++ b/api-reference/person/find.mdx
@@ -169,7 +169,7 @@ curl --location --request POST 'https://api.travtus.com/persons/find/' \
   "phone_number": "01234567890",
   "groups_external_refs": ["group-1"],
   "after-id": 1
-}
+}'
 ```
 
 </RequestExample>

--- a/api-reference/unit/find.mdx
+++ b/api-reference/unit/find.mdx
@@ -249,7 +249,7 @@ curl --location --request POST 'https://api.travtus.com/units/find/' \
   },
   "group_ids": ["group-1"],
   "after-id": 1
-}
+}'
 ```
 
 </RequestExample>

--- a/api-reference/unit/post-multiple.mdx
+++ b/api-reference/unit/post-multiple.mdx
@@ -298,7 +298,7 @@ Returned if no group for the provided group ID is found
 <RequestExample>
 
 ```bash Example Request
-curl --location --request "POST 'https://api.travtus.com/units/multiple/' \
+curl --location --request "POST 'https://api.travtus.com/units/multiple/'" \
 --header 'Content-Type: application/json' \
 --header 'Authorization: bearer <token>' \
 --data-raw '{


### PR DESCRIPTION
Add errors for the listing find and sync endpoints for cases where a user attempts to perform one of these operations on a portfolio that they don't have access to or when a user does not provide a portfolio id or external reference when they have to provide one.

Fix a bug on several endpoints where missing closing single and double quotes broke request and response examples.