### PR TITLE
Add warnings about certain embeds

### DIFF
--- a/chat_widget.mdx
+++ b/chat_widget.mdx
@@ -4,17 +4,20 @@ title: "Chat Widget Installation"
 
 ## Widget Installation
 
+<Warning>We do not currently support embedding the chat widget on a locally hosted environment.</Warning>
+
+<Warning>The chat widget must be embedded in an environment accessible through the public internet.</Warning>
 
 To embed the Adam Chat widget: 
 
 Include stylesheet 
 ```
-<link href="https://uat-adam-chat.travtus.com/v2/index.css"  rel="stylesheet">
+<link href="https://uat-adam3-chat.travtus.com/v2/index.css"  rel="stylesheet">
 ```
 
 Include JS library 
 ```
-<script src="https://uat-adam-chat.travtus.com/v2/index.js"></script>
+<script src="https://uat-adam3-chat.travtus.com/v2/index.js"></script>
 ```
 
 Initialize Adam Chat widget by calling 
@@ -38,8 +41,8 @@ Please see the Widget API section for more details about what can be passed as o
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title> Adam Widget</title>
-   <link href="https://uat-adam-chat.travtus.com/v2/index.css" rel="stylesheet">
-   <script src="https://uat-adam-chat.travtus.com/v2/index.js"></script>
+   <link href="https://uat-adam3-chat.travtus.com/v2/index.css" rel="stylesheet">
+   <script src="https://uat-adam3-chat.travtus.com/v2/index.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
Add warnings on the chat widget embedding documentation about using local environments or environments not accessible via the public internet, as the chat widget is currently only functional when embedded on an environment accessible via the public internet.