### PR TITLE
Add docs for sideloading Gateway

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -165,6 +165,17 @@
       ]
     },
     {
+      "group": "Miscellaneous",
+      "pages": [
+        {
+          "group": "Chrome Extension",
+          "pages": [
+            "miscellaneous/chrome-extension/sideloading-gateway-on-chrome"
+          ]
+        }
+      ]
+    },
+    {
       "group": "Glossary",
       "pages": [
         "glossary/glossary"

--- a/miscellaneous/chrome-extension/sideloading-gateway-on-chrome.mdx
+++ b/miscellaneous/chrome-extension/sideloading-gateway-on-chrome.mdx
@@ -1,0 +1,38 @@
+---
+title: "Sideloading Gateway on Chrome"
+description: "Guide for sideloading the Travtus Gateway on Chrome browser"
+---
+
+## Prerequisites
+
+Before you begin, ensure you have:
+
+- Google Chrome browser installed
+- Developer mode enabled in Chrome
+- The Travtus Gateway extension files
+
+### Download the Extension
+
+📥 **[Download Gateway Chrome Extension](https://travtus-website-assets.s3.us-east-2.amazonaws.com/gateway-chrome.zip)** (Version 1.11.0 - Released June 30th, 2025)
+
+Extract the downloaded `gateway-chrome.zip` file to a folder on your computer before proceeding with the installation steps below.
+
+## Steps to Sideload
+
+### 1. Enable Developer Mode
+
+1. Open Google Chrome
+2. Navigate to `chrome://extensions/`
+3. Toggle on "Developer mode" in the top right corner
+
+### 2. Load the Extension
+
+1. Click "Load unpacked" button
+2. Select the folder containing the Travtus Gateway extension files
+3. The extension should now appear in your extensions list
+
+### 3. Verify Installation
+
+1. Check that the Travtus Gateway extension is enabled
+2. Look for the extension icon in your Chrome toolbar
+3. Test the extension functionality


### PR DESCRIPTION
This pull request introduces a new guide for sideloading the Travtus Gateway Chrome extension and updates the `mint.json` file to include it under a newly added "Miscellaneous" group. The most important changes are the addition of the guide content and the structural update to the documentation configuration.

### Documentation updates:

* [`mint.json`](diffhunk://#diff-f42b3e455b64bd6a447c4a0af574f6f957b5ad387d55c42c3a38d4473476b854R167-R177): Added a new "Miscellaneous" group with a nested "Chrome Extension" subgroup, linking to the new guide on sideloading the Travtus Gateway on Chrome.

* [`miscellaneous/chrome-extension/sideloading-gateway-on-chrome.mdx`](diffhunk://#diff-f290f7a40cdbba396117d363736a04888d4b9f07460a7545cefd7111555be123R1-R38): Created a new guide titled "Sideloading Gateway on Chrome," which provides step-by-step instructions for installing the Travtus Gateway Chrome extension, including prerequisites, download links, and verification steps.