### PR TITLE
Add new fields for community, resident, and unit data structures

### DIFF
--- a/deployment-guide/file-uploads/data-types-and-data-structure/community.mdx
+++ b/deployment-guide/file-uploads/data-types-and-data-structure/community.mdx
@@ -18,6 +18,7 @@ description: "The fields below are accepted via .csv file transfer. Upon receipt
 
 <ParamField body="address_line_1" default="none" type="string" required>
   The first line of the address for the community you want to create.
+  </ParamField>
 
 <ParamField path="address_line_2" type="string">
   Second
@@ -61,4 +62,96 @@ description: "The fields below are accepted via .csv file transfer. Upon receipt
 
 <ParamField path="year_built" type="string">
   Year that the property was built
+</ParamField>
+
+<ParamField path="property_manager" type="string">
+  The name of the property manager responsible for the community.
+</ParamField>
+
+<ParamField path="property_management_company" type="string">
+  The name of the property management company overseeing the community.
+</ParamField>
+
+<ParamField path="commercial_units" type="integer">
+  The number of commercial units within the community.
+</ParamField>
+
+<ParamField path="commercial_square_footage" type="float">
+  The total square footage of commercial space in the community.
+</ParamField>
+
+<ParamField path="capitalization_rate" type="float">
+  The capitalization rate for the property investment.
+</ParamField>
+
+<ParamField path="community_property_type" type="string">
+  The type of property for the community (e.g., Apartment, Townhome, Single Family).
+</ParamField>
+
+<ParamField path="property_floor_count" type="integer">
+  The number of floors in the property buildings.
+</ParamField>
+
+<ParamField path="property_building_count" type="integer">
+  The total number of buildings in the community.
+</ParamField>
+
+<ParamField path="elevator" type="boolean">
+  Indicates whether the property has elevator access.
+</ParamField>
+
+<ParamField path="parking_count" type="integer">
+  The number of parking spaces available in the community.
+</ParamField>
+
+<ParamField path="mortgage_amount" type="float">
+  The total mortgage amount for the property.
+</ParamField>
+
+<ParamField path="mortgage_term" type="integer">
+  The term of the mortgage in years.
+</ParamField>
+
+<ParamField path="mortgage_rate_type" type="string">
+  The type of mortgage rate (e.g., Fixed, Variable, ARM).
+</ParamField>
+
+<ParamField path="mortgage_index" type="string">
+  The index used for variable rate mortgages (e.g., LIBOR, Prime).
+</ParamField>
+
+<ParamField path="mortgage_interest_rate_spread" type="float">
+  The interest rate spread above the mortgage index.
+</ParamField>
+
+<ParamField path="mortgage_amortization" type="integer">
+  The amortization period for the mortgage in years.
+</ParamField>
+
+<ParamField path="mortgage_due_date" type="date">
+  The due date for the mortgage.
+</ParamField>
+
+<ParamField path="region" type="string">
+  The geographical region where the community is located.
+</ParamField>
+
+<ParamField path="assessor_parcel_number" type="string">
+  The assessor's parcel number for the property.
+</ParamField>
+
+<ParamField path="legal_description" type="string">
+  The legal description of the property.
+</ParamField>
+
+<ParamField path="property_total_square_footage" type="float">
+  The total square footage of all buildings in the property.
+</ParamField>
+
+<ParamField path="property_parcel_size" type="float">
+  The size of the property parcel in acres or square feet.
+</ParamField>
+
+<ParamField path="pms_name" type="string">
+  The name of the Property Management System (PMS) used for the community.
 </ParamField>

--- a/deployment-guide/file-uploads/data-types-and-data-structure/resident.mdx
+++ b/deployment-guide/file-uploads/data-types-and-data-structure/resident.mdx
@@ -150,3 +150,51 @@ Below is our standard data structure for a resident:
 <ParamField body="cell_3" type="string" default="none">
     A third alternative cell phone number of the resident you want to create.
 </ParamField>
+
+<ParamField body="middle_name" type="string" default="none">
+  The middle name of the resident.
+</ParamField>
+
+<ParamField body="date_of_birth" type="date" default="none">
+  The date of birth of the resident.
+</ParamField>
+
+<ParamField body="gender" type="string" default="none">
+  The gender of the resident.
+</ParamField>
+
+<ParamField body="company_name" type="string" default="none">
+  The name of the company where the resident is employed.
+</ParamField>
+
+<ParamField body="job_title" type="string" default="none">
+  The job title of the resident at their company.
+</ParamField>
+
+<ParamField body="company_address_1" type="string" default="none">
+  The first line of the company address for the resident.
+</ParamField>
+
+<ParamField body="company_address_city" type="string" default="none">
+  The city of the company address for the resident.
+</ParamField>
+
+<ParamField body="company_address_state" type="string" default="none">
+  The state of the company address for the resident.
+</ParamField>
+
+<ParamField body="company_address_zip_code" type="string" default="none">
+  The zip code of the company address for the resident.
+</ParamField>
+
+<ParamField body="company_phone" type="string" default="none">
+  The phone number of the resident's company.
+</ParamField>
+
+<ParamField body="company_email" type="string" default="none">
+  The email address of the resident at their company.
+</ParamField>
+
+<ParamField body="company_start_date" type="date" default="none">
+  The start date of the resident's employment at their company.
+</ParamField>

--- a/deployment-guide/file-uploads/data-types-and-data-structure/unit.mdx
+++ b/deployment-guide/file-uploads/data-types-and-data-structure/unit.mdx
@@ -63,3 +63,31 @@ Below is our standard data structure for a unit:
 <ParamField body="sqft" type="string" default="none">
   The square feet for the unit you want to create.
 </ParamField>
+
+<ParamField body="unit_floorplan_url" type="string" default="none">
+  The URL to the floorplan image for the unit.
+</ParamField>
+
+<ParamField body="unit_image_url" type="string" default="none">
+  The URL to the main image for the unit.
+</ParamField>
+
+<ParamField body="unit_status" type="string" default="none">
+  The current status of the unit (e.g., Available, Occupied, Maintenance).
+</ParamField>
+
+<ParamField body="is_corporate_rented" type="boolean" default="false">
+  Indicates whether the unit is rented by a corporate entity.
+</ParamField>
+
+<ParamField body="on_notice" type="boolean" default="false">
+  Indicates whether the unit is currently on notice (tenant has given notice to vacate).
+</ParamField>
+
+<ParamField body="on_market" type="boolean" default="false">
+  Indicates whether the unit is currently available for rent on the market.
+</ParamField>
+
+<ParamField body="floor_number" type="integer" default="none">
+  The floor number where the unit is located.
+</ParamField>


### PR DESCRIPTION
This pull request expands the data structure documentation for community, resident, and unit entities in the deployment guide. The changes introduce new fields to enhance the comprehensiveness of the `.csv` file upload format for these entities.

### Additions to Community Data Structure:
* Added fields for property details, including `property_manager`, `property_management_company`, `commercial_units`, `capitalization_rate`, and more, to capture detailed property and financial information.

### Additions to Resident Data Structure:
* Added fields such as `middle_name`, `date_of_birth`, `gender`, and employment-related fields like `company_name`, `job_title`, and `company_start_date` to provide a more complete profile of residents.

### Additions to Unit Data Structure:
* Introduced fields like `unit_floorplan_url`, `unit_status`, `is_corporate_rented`, and `floor_number` to better describe unit attributes and their current state.

### Minor Fix:
* Closed an unclosed `ParamField` tag for `address_line_1` in the community data structure.