### PR TITLE
Fix embedded Gateway configurator URL

### DIFF
--- a/deployment-guide/embedded-gateway.mdx
+++ b/deployment-guide/embedded-gateway.mdx
@@ -8,7 +8,7 @@ The Embedded Gateway allows the Travtus Gateway to be seamlessly integrated into
 
 ## Installation
 
-To embed the Gateway, include the following script before the `</body>` tag on every page where you want the Gateway to appear. You will need to replace `CONFIG_OBJECT` with the configuration object generated from our [online configurator generator](https://generate.notarealurl.com).
+To embed the Gateway, include the following script before the `</body>` tag on every page where you want the Gateway to appear. You will need to replace `CONFIG_OBJECT` with the configuration object generated from our [online configurator generator](https://embedded-gateway-configurator.netlify.app).
 
 ```html
 <script>


### PR DESCRIPTION
This pull request makes a minor update to the documentation for embedding the Travtus Gateway. The change replaces an outdated link to the online configurator generator with the correct URL.

* Updated the embedded Gateway installation instructions to reference the correct online configurator generator URL in `deployment-guide/embedded-gateway.mdx`.