### PR TITLE
Add API usage examples and token expiry details for authentication

### DIFF
--- a/deployment-guide/file-uploads/data-types-and-data-structure/agents.mdx
+++ b/deployment-guide/file-uploads/data-types-and-data-structure/agents.mdx
@@ -3,7 +3,7 @@ title: "Agents"
 description: "The fields below are accepted via .csv file transfer to the AGENT folder. Upon receipt the file will be uploaded, creating or updating agent records held within the Travtus platform. This data is used to enhance the agent and talent score matching process when agent information is incomplete."
 ---
 
-Upload your file to the `AGENT` folder using the S3 key format: `companyName_companyId/AGENT/filename.csv`. See [File Requirements & Validation](../file-requirements) for encoding, delimiter, and validation rules.
+Upload your file using the S3 key format `companyName_companyId/AGENT/filename.csv`, where `AGENT` is the `TYPE-SUBTYPE` value for this upload. See [File Requirements & Validation](../file-requirements) for encoding, delimiter, and validation rules.
 
 <ParamField path="agent_id" type="string" required>
   The client's external reference ID for the agent. Used to uniquely identify the agent in the Travtus platform. Records without this field will be skipped.

--- a/deployment-guide/file-uploads/data-types-and-data-structure/agents.mdx
+++ b/deployment-guide/file-uploads/data-types-and-data-structure/agents.mdx
@@ -1,0 +1,34 @@
+---
+title: "Agents"
+description: "The fields below are accepted via .csv file transfer to the AGENT folder. Upon receipt the file will be uploaded, creating or updating agent records held within the Travtus platform. This data is used to enhance the agent and talent score matching process when agent information is incomplete."
+---
+
+Upload your file to the `AGENT` folder using the S3 key format: `companyName_companyId/AGENT/filename.csv`. See [File Requirements & Validation](../file-requirements) for encoding, delimiter, and validation rules.
+
+<ParamField path="agent_id" type="string" required>
+  The client's external reference ID for the agent. Used to uniquely identify the agent in the Travtus platform. Records without this field will be skipped.
+</ParamField>
+
+<ParamField path="first_name" type="string">
+  The first name of the agent.
+</ParamField>
+
+<ParamField path="last_name" type="string">
+  The last name of the agent.
+</ParamField>
+
+<ParamField path="full_name" type="string">
+  The full name of the agent. Can be provided directly or derived from first and last name.
+</ParamField>
+
+<ParamField path="email_address" type="string">
+  The email address of the agent.
+</ParamField>
+
+<ParamField path="phone_number" type="string">
+  The phone number of the agent. Must be a valid phone number in E.164 format (e.g. +12025551234).
+</ParamField>
+
+<ParamField path="source" type="string">
+  The source system or origin of the agent data.
+</ParamField>

--- a/deployment-guide/file-uploads/data-types-and-data-structure/agents.mdx
+++ b/deployment-guide/file-uploads/data-types-and-data-structure/agents.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Agents"
-description: "The fields below are accepted via .csv file transfer to the AGENT folder. Upon receipt the file will be uploaded, creating or updating agent records held within the Travtus platform. This data is used to enhance the agent and talent score matching process when agent information is incomplete."
+description: "The fields below are accepted via .csv file transfer to the AGENT folder. Upon receipt the file will be uploaded, creating or updating agent records held within the Travtus platform. Agents are human employees responsible for responding to renters, tenants, prospects, and similar contacts. This data is used to enhance the agent and talent score matching process when agent information is incomplete."
 ---
 
 Upload your file using the S3 key format `companyName_companyId/AGENT/filename.csv`, where `AGENT` is the `TYPE-SUBTYPE` value for this upload. See [File Requirements & Validation](../file-requirements) for encoding, delimiter, and validation rules.
 
 <ParamField path="agent_id" type="string" required>
-  The client's external reference ID for the agent. Used to uniquely identify the agent in the Travtus platform. Records without this field will be skipped.
+  The client's external reference ID for the agent. Used to uniquely identify and match the agent in the Travtus platform. Records without this field will be skipped.
 </ParamField>
 
 <ParamField path="first_name" type="string">
@@ -27,6 +27,7 @@ Upload your file using the S3 key format `companyName_companyId/AGENT/filename.c
 
 <ParamField path="phone_number" type="string">
   The phone number of the agent. Must be a valid phone number in E.164 format (e.g. +12025551234).
+  If a phone number is linked to multiple agents, it can cause issues when matching the correct agent. Avoid providing `phone_number` in those cases.
 </ParamField>
 
 <ParamField path="source" type="string">

--- a/deployment-guide/file-uploads/data-types-and-data-structure/users.mdx
+++ b/deployment-guide/file-uploads/data-types-and-data-structure/users.mdx
@@ -1,7 +1,9 @@
 ---
 title: "Users"
-description: "Below is our standard data structure for Users"
+description: "The fields below are accepted via .csv file transfer to the USER folder. Upon receipt the file will be uploaded, creating or updating user records held within the Travtus platform."
 ---
+
+Upload your file to the `USER` folder using the S3 key format: `companyName_companyId/USER/filename.csv`. See [File Requirements & Validation](../file-requirements) for encoding, delimiter, and validation rules.
 
 <ParamField path="email_address" body="email_address" type="string" required>
   The email address of the user. 

--- a/deployment-guide/file-uploads/data-types-and-data-structure/users.mdx
+++ b/deployment-guide/file-uploads/data-types-and-data-structure/users.mdx
@@ -3,7 +3,7 @@ title: "Users"
 description: "The fields below are accepted via .csv file transfer to the USER folder. Upon receipt the file will be uploaded, creating or updating user records held within the Travtus platform."
 ---
 
-Upload your file to the `USER` folder using the S3 key format: `companyName_companyId/USER/filename.csv`. See [File Requirements & Validation](../file-requirements) for encoding, delimiter, and validation rules.
+Upload your file using the S3 key format `companyName_companyId/USER/filename.csv`, where `USER` is the `TYPE-SUBTYPE` folder value for user uploads. See [File Requirements & Validation](../file-requirements) for encoding, delimiter, and validation rules.
 
 <ParamField path="email_address" body="email_address" type="string" required>
   The email address of the user. 

--- a/docs.json
+++ b/docs.json
@@ -161,6 +161,7 @@
                   "deployment-guide/file-uploads/data-types-and-data-structure/vacancy",
                   "deployment-guide/file-uploads/data-types-and-data-structure/resident",
                   "deployment-guide/file-uploads/data-types-and-data-structure/users",
+                  "deployment-guide/file-uploads/data-types-and-data-structure/agents",
                   {
                     "group": "Messages",
                     "pages": [

--- a/travtus-api-and-webhook/authentication.mdx
+++ b/travtus-api-and-webhook/authentication.mdx
@@ -30,7 +30,7 @@ Travtus API uses token authentication. All API calls must include the following 
 </ResponseField>
 
 <ResponseField name="expires_in" type="integer">
-  Token expiry time in seconds. The access token is valid for **3600 seconds (60 minutes)**. You must re-authenticate once it expires.
+  Token expiry time in seconds. The access token is valid for **3600 seconds (60 minutes)**. Once it expires, request a new access token using the same client credentials.
 </ResponseField>
 
 <RequestExample>
@@ -61,24 +61,28 @@ access_token = token_data['access_token']
 ```
 
 ```typescript Get Token
-const params = new URLSearchParams({
-  grant_type: 'client_credentials',
-  client_id: '<client-id>',
-  client_secret: '<client-secret>',
-});
+async function getToken() {
+  const params = new URLSearchParams({
+    grant_type: 'client_credentials',
+    client_id: '<client-id>',
+    client_secret: '<client-secret>',
+  });
 
-const response = await fetch(
-  'https://travtus-api.auth.us-east-2.amazoncognito.com/oauth2/token',
-  {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: params,
-  }
-);
+  const response = await fetch(
+    'https://travtus-api.auth.us-east-2.amazoncognito.com/oauth2/token',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: params,
+    }
+  );
 
-const tokenData = await response.json();
-const accessToken = tokenData.access_token;
-// Note: token expires in 3600 seconds (60 minutes)
+  const tokenData = await response.json();
+  const accessToken = tokenData.access_token;
+  // Note: token expires in 3600 seconds (60 minutes)
+}
+
+getToken();
 ```
 
 </RequestExample>

--- a/travtus-api-and-webhook/authentication.mdx
+++ b/travtus-api-and-webhook/authentication.mdx
@@ -29,6 +29,10 @@ Travtus API uses token authentication. All API calls must include the following 
   The token you will need to use in order to access any other API endpoints.
 </ResponseField>
 
+<ResponseField name="expires_in" type="integer">
+  Token expiry time in seconds. The access token is valid for **3600 seconds (60 minutes)**. You must re-authenticate once it expires.
+</ResponseField>
+
 <RequestExample>
 
 ```bash Example Request
@@ -37,6 +41,44 @@ curl --location --request POST 'https://travtus-api.auth.us-east-2.amazoncognito
 --data-urlencode 'grant_type=client_credentials' \
 --data-urlencode 'client_id=<client-id>' \
 --data-urlencode 'client_secret=<client-secret>'
+```
+
+```python Get Token
+import requests
+
+response = requests.post(
+    'https://travtus-api.auth.us-east-2.amazoncognito.com/oauth2/token',
+    headers={'Content-Type': 'application/x-www-form-urlencoded'},
+    data={
+        'grant_type': 'client_credentials',
+        'client_id': '<client-id>',
+        'client_secret': '<client-secret>',
+    }
+)
+token_data = response.json()
+access_token = token_data['access_token']
+# Note: token expires in 3600 seconds (60 minutes)
+```
+
+```typescript Get Token
+const params = new URLSearchParams({
+  grant_type: 'client_credentials',
+  client_id: '<client-id>',
+  client_secret: '<client-secret>',
+});
+
+const response = await fetch(
+  'https://travtus-api.auth.us-east-2.amazoncognito.com/oauth2/token',
+  {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: params,
+  }
+);
+
+const tokenData = await response.json();
+const accessToken = tokenData.access_token;
+// Note: token expires in 3600 seconds (60 minutes)
 ```
 
 </RequestExample>
@@ -48,6 +90,84 @@ curl --location --request POST 'https://travtus-api.auth.us-east-2.amazoncognito
 ```
 
 </ResponseExample>
+
+### Using the Token
+
+<Note>
+  The bearer token is valid for **60 minutes** (3600 seconds). Once it expires, you must re-authenticate to obtain a new token before making further API calls.
+</Note>
+
+Use the `access_token` from the authentication response as a Bearer token in the `Authorization` header of all subsequent API requests.
+
+<CodeGroup>
+
+```python Python
+import requests
+import json
+
+url = "https://api.travtus.com/messages/"
+
+payload = json.dumps({
+  "channel": "email",
+  "group_external_ref": "<community-external-ref>",
+  "first_name": "First",
+  "last_name": "Last",
+  "email": {
+    "source": "<source>",
+    "message_id": "<message-id>",
+    "text": "<message-text>",
+    "created_datetime": "2025-06-27T16:45:13.000000",
+    "from_email_address": "<from-email>",
+    "to_email_addresses": "<to-email>",
+    "subject": "<subject>",
+    "conversation_id": "<conversation-id>",
+    "references": []
+  }
+})
+headers = {
+  'Content-Type': 'application/json',
+  'Authorization': 'Bearer <access_token>'
+}
+
+response = requests.post(url, headers=headers, data=payload)
+print(response.text)
+```
+
+```typescript TypeScript
+const url = "https://api.travtus.com/messages/";
+
+const payload = {
+  channel: "email",
+  group_external_ref: "<community-external-ref>",
+  first_name: "First",
+  last_name: "Last",
+  email: {
+    source: "<source>",
+    message_id: "<message-id>",
+    text: "<message-text>",
+    created_datetime: "2025-06-27T16:45:13.000000",
+    from_email_address: "<from-email>",
+    to_email_addresses: "<to-email>",
+    subject: "<subject>",
+    conversation_id: "<conversation-id>",
+    references: [],
+  },
+};
+
+const response = await fetch(url, {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    Authorization: "Bearer <access_token>",
+  },
+  body: JSON.stringify(payload),
+});
+
+const data = await response.json();
+console.log(data);
+```
+
+</CodeGroup>
 
 ---
 

--- a/travtus-api-and-webhook/authentication.mdx
+++ b/travtus-api-and-webhook/authentication.mdx
@@ -83,8 +83,12 @@ async function getToken() {
   return accessToken;
 }
 
-const accessToken = await getToken();
-console.log(accessToken);
+async function main() {
+  const accessToken = await getToken();
+  console.log(accessToken);
+}
+
+main();
 ```
 
 </RequestExample>

--- a/travtus-api-and-webhook/authentication.mdx
+++ b/travtus-api-and-webhook/authentication.mdx
@@ -80,9 +80,11 @@ async function getToken() {
   const tokenData = await response.json();
   const accessToken = tokenData.access_token;
   // Note: token expires in 3600 seconds (60 minutes)
+  return accessToken;
 }
 
-getToken();
+const accessToken = await getToken();
+console.log(accessToken);
 ```
 
 </RequestExample>
@@ -149,7 +151,7 @@ const payload = {
     source: "<source>",
     message_id: "<message-id>",
     text: "<message-text>",
-    created_datetime: "2025-06-27T16:45:13.000000",
+    created_datetime: "2025-06-27T16:45:13.000000Z",
     from_email_address: "<from-email>",
     to_email_addresses: "<to-email>",
     subject: "<subject>",
@@ -158,17 +160,21 @@ const payload = {
   },
 };
 
-const response = await fetch(url, {
-  method: "POST",
-  headers: {
-    "Content-Type": "application/json",
-    Authorization: "Bearer <access_token>",
-  },
-  body: JSON.stringify(payload),
-});
+async function sendMessage() {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer <access_token>",
+    },
+    body: JSON.stringify(payload),
+  });
 
-const data = await response.json();
-console.log(data);
+  const data = await response.json();
+  console.log(data);
+}
+
+sendMessage();
 ```
 
 </CodeGroup>


### PR DESCRIPTION

## What is the goal of this PR?

This pull request introduces several documentation improvements, focusing on expanding data upload guides and clarifying API authentication. The most notable changes are the addition of a new Agents data upload guide, enhancements to the Users upload documentation, and significant improvements to the authentication section, including token usage details and code examples.

**New and Updated Data Upload Documentation:**

* Added a new `Agents` data upload guide (`agents.mdx`), detailing accepted fields, S3 upload instructions, and validation requirements for agent records.
* Updated the `Users` data upload guide (`users.mdx`) to include S3 upload instructions and a link to file requirements and validation rules.
* Registered the new `agents.mdx` page in the documentation navigation (`docs.json`).

**API Authentication Documentation Improvements:**

* Added documentation for the `expires_in` field in the authentication response, clarifying that tokens are valid for 3600 seconds (60 minutes) and require re-authentication upon expiry.
* Added Python and TypeScript code examples for obtaining an access token using the client credentials grant.
* Added a new section on using the bearer token, including a note on token expiry and practical code examples in both Python and TypeScript for making authenticated API requests.