### PR TITLE
Add message direction feature

### DIFF
--- a/travtus-api-and-webhook/data-types-and-endpoints/messaging/messaging-api-v2.0.mdx
+++ b/travtus-api-and-webhook/data-types-and-endpoints/messaging/messaging-api-v2.0.mdx
@@ -40,6 +40,7 @@ If omitted for Web Chat, Travtus generates one automatically and returns it in t
 | Field                | Type             | Required    | Description                         |
 | -------------------- | ---------------- | ----------- | ----------------------------------- |
 | `channel`            | string           | Yes         | `"sms"`, `"email"`, `"web_chat"`, or `"call_transcript"` |
+| `message_direction`  | string           | Yes         | `"Inbound"` or `"Outbound"`         |
 | `group_id`           | UUID             | Conditional | Internal group/portfolio ID         |
 | `group_external_ref` | string           | Conditional | External group/portfolio reference  |
 | `first_name`         | string           | No          | Sender first name                   |
@@ -56,6 +57,7 @@ If omitted for Web Chat, Travtus generates one automatically and returns it in t
 ```json
 {
   "channel": "sms",
+  "message_direction": "Inbound",
   "group_external_ref": "portfolio_123",
   "first_name": "Jane",
   "last_name": "Doe",
@@ -92,6 +94,7 @@ If omitted for Web Chat, Travtus generates one automatically and returns it in t
 ```json
 {
   "channel": "email",
+  "message_direction": "Inbound",
   "group_external_ref": "portfolio_123",
   "first_name": "Jane",
   "last_name": "Doe",
@@ -144,6 +147,7 @@ If omitted for Web Chat, Travtus generates one automatically and returns it in t
 ```json
 {
   "channel": "web_chat",
+  "message_direction": "Inbound",
   "group_id": "b0234194-e61b-4a57-967f-6eaaee4d5219",
   "first_name": "John",
   "last_name": "Doe",
@@ -182,6 +186,7 @@ If omitted for Web Chat, Travtus generates one automatically and returns it in t
 ```json
 {
   "channel": "call_transcript",
+  "message_direction": "Inbound",
   "group_id": "b0234194-e61b-4a57-967f-6eaaee4d5219",
   "first_name": "John",
   "last_name": "Doe",


### PR DESCRIPTION

## What is the goal of this PR?

 
This pull request updates the messaging API documentation to include the new required field `message_direction` for all supported channels. The changes clarify that clients must specify whether a message is "Inbound" or "Outbound" and update all relevant examples to demonstrate this.

**API documentation updates:**

* Added the `message_direction` field (required; values: `"Inbound"` or `"Outbound"`) to the message payload table in `messaging-api-v2.0.mdx`.

**Example payload updates:**

* Updated all JSON examples for `sms`, `email`, `web_chat`, and `call_transcript` channels to include the new `message_direction` field. [[1]](diffhunk://#diff-10948cf2644ec5ac5992ce4e49518bc9460d424affcc42cf08da9875df50a45bR60) [[2]](diffhunk://#diff-10948cf2644ec5ac5992ce4e49518bc9460d424affcc42cf08da9875df50a45bR97) [[3]](diffhunk://#diff-10948cf2644ec5ac5992ce4e49518bc9460d424affcc42cf08da9875df50a45bR150) [[4]](diffhunk://#diff-10948cf2644ec5ac5992ce4e49518bc9460d424affcc42cf08da9875df50a45bR189)