### PR TITLE
Add agent details to messaging API response and update field descriptions

### DIFF
--- a/deployment-guide/file-uploads/sftp-upload.mdx
+++ b/deployment-guide/file-uploads/sftp-upload.mdx
@@ -4,6 +4,8 @@ title: "SFTP Upload"
 
 As an alternative to uploading files directly with S3 credentials (see [Authentication & Access](./process-and-auth)), you can upload your files over SFTP using a client such as WinSCP, FileZilla, the `sftp` command line, or a scheduled job. Files uploaded over SFTP go through the same Travtus ingestion pipeline, so all [file format rules and validations](./file-requirements) still apply.
 
+SFTP can also be used to upload [Bring Your Own Data (BYOD)](./BYOD) datasets — the connection steps and directory conventions below apply to both standard file uploads and BYOD.
+
 ## Request Credentials
 
 First, request your SFTP credentials by contacting our support team at [support@travtus.com](mailto:support@travtus.com). You will receive the following information:
@@ -133,7 +135,5 @@ By following these steps, you can upload your data files over SFTP to the Travtu
 For any questions or assistance, please contact our support team at [support@travtus.com](mailto:support@travtus.com).
 
 To see more about the standard data structures for these entities, click [here](/deployment-guide/file-uploads/data-types-and-data-structure/community).
-
-Thank you for choosing Travtus!
 
 ---

--- a/travtus-api-and-webhook/data-types-and-endpoints/messaging/messaging-api-v2.0.mdx
+++ b/travtus-api-and-webhook/data-types-and-endpoints/messaging/messaging-api-v2.0.mdx
@@ -70,20 +70,30 @@ If omitted for Web Chat, Travtus generates one automatically and returns it in t
     "created_datetime": "2024-03-15T11:30:00Z",
     "phone_number": "+1234567890",
     "sent_to_phone_number": "+10987654321",
-    "conversation_id": "conv_abc123"
+    "conversation_id": "conv_abc123",
+    "agent_id": "agent_123",
+    "agent_full_name": "Alex Smith",
+    "agent_first_name": "Alex",
+    "agent_last_name": "Smith",
+    "agent_phone_number": "+10987654321"
   }
 }
 ```
 
-| Field                     | Type   | Required | Description                             |
-| ------------------------- | ------ | -------- | --------------------------------------- |
-| `sms.source`              | string | No       | SMS provider name (default `"unknown"`) |
-| `sms.message_id`          | string | Yes      | Unique message identifier               |
-| `sms.text`                | string | Yes      | Message content                         |
-| `sms.created_datetime`    | string | Yes      | ISO 8601 timestamp                      |
-| `sms.phone_number`        | string | Yes      | Sender’s phone number (E.164 format)    |
+| Field                      | Type   | Required | Description                             |
+| -------------------------- | ------ | -------- | --------------------------------------- |
+| `sms.source`               | string | No       | SMS provider name (default `"unknown"`) |
+| `sms.message_id`           | string | Yes      | Unique message identifier               |
+| `sms.text`                 | string | Yes      | Message content                         |
+| `sms.created_datetime`     | string | Yes      | ISO 8601 timestamp                      |
+| `sms.phone_number`         | string | Yes      | Sender’s phone number (E.164 format)    |
 | `sms.sent_to_phone_number` | string | No       | Recipient phone number (E.164 format)   |
-| `sms.conversation_id`     | string | Yes      | Conversation thread ID                  |
+| `sms.conversation_id`      | string | Yes      | Conversation thread ID                  |
+| `sms.agent_id`             | string | No       | Agent identifier                        |
+| `sms.agent_full_name`      | string | No       | Agent full name                         |
+| `sms.agent_first_name`     | string | No       | Agent first name                        |
+| `sms.agent_last_name`      | string | No       | Agent last name                         |
+| `sms.agent_phone_number`   | string | No       | Agent phone number (E.164 format)       |
 
 ---
 


### PR DESCRIPTION

## What is the goal of this PR?

 
This pull request makes documentation updates to improve clarity and add details about SFTP file uploads and the messaging API response structure. The most important changes are:

**SFTP Upload Documentation Improvements:**

* Clarified that SFTP can also be used to upload Bring Your Own Data (BYOD) datasets, and that the connection steps and directory conventions apply to both standard uploads and BYOD.
* Removed a redundant closing thank-you line to streamline the SFTP upload guide.

**Messaging API Response Update:**

* Updated the example messaging API v2.0 response and its documentation to include additional agent-related fields: `agent_id`, `agent_full_name`, `agent_first_name`, `agent_last_name`, and `agent_phone_number`. This provides more context about the agent associated with each message.