### PR TITLE
Document chat widget position option

### DIFF
--- a/deployment-guide/chat-widget-deployment.mdx
+++ b/deployment-guide/chat-widget-deployment.mdx
@@ -138,10 +138,10 @@ Sets which corner of the viewport the launcher and chat window appear in on desk
 
 Pass one of the following values:
 
-    - **TL** - top left
-    - **TR** - top right
-    - **BL** - bottom left
-    - **BR** - bottom right
+- **TL** - top left
+- **TR** - top right
+- **BL** - bottom left
+- **BR** - bottom right
 </Accordion>
 
 <Accordion title="breakpoint">

--- a/deployment-guide/chat-widget-deployment.mdx
+++ b/deployment-guide/chat-widget-deployment.mdx
@@ -131,10 +131,23 @@ When passing a `colors` object, the icon on the launcher button will change from
 
 </Accordion>
 
+<Accordion title="position">
+`string`
+
+Sets which corner of the viewport the launcher and chat window appear in on desktop. Defaults to `"BR"` (bottom right).
+
+Pass one of the following values:
+
+    - **TL** - top left
+    - **TR** - top right
+    - **BL** - bottom left
+    - **BR** - bottom right
+</Accordion>
+
 <Accordion title="breakpoint">
 `number`
 
-This is the resolution at which the chat window should switch from full screen (mobile view) to an overlay in the bottom right (desktop view). Defaults to `769` (tablet portrait).
+This is the resolution at which the chat window should switch from full screen (mobile view) to a corner overlay (desktop view). The corner is determined by the `position` option. Defaults to `769` (tablet portrait).
 
 Mobile view:
 
@@ -173,6 +186,7 @@ AdamChat.init('adam-bot', {
     foreground: "#000000",
     text: "#000000",
   },
+  position: "BR",
   breakpoint: 641,
   hideLauncherOnMobile: false,
   hideFooter: false,

--- a/deployment-guide/embedded-gateway.mdx
+++ b/deployment-guide/embedded-gateway.mdx
@@ -50,7 +50,7 @@ The configuration object allows you to customize the behavior and appearance of 
   If you are integrating a SAML solution please state the identity provider name given by Travtus here.
 
 - **redirectUri**: `string` (optional)
-  If you are integrating a SAML solution please state the redirect URL given by Travtus here.
+  If you are integrating a SAML solution please state the redirect URL provided by Travtus here.
 
 ## Methods
 


### PR DESCRIPTION
## Summary
- Documents the new `position` init option (`TL`, `TR`, `BL`, `BR`) for desktop launcher and chat window placement
- Updates the `breakpoint` description so it no longer implies the overlay is always bottom-right
- Adds `position` to the full options example

## Test plan
- [ ] Review the updated Chat Widget Deployment page in Mintlify/docs preview
- [ ] Confirm option names and default (`BR`) match `adam-widget` `feature/widget-position-config`


Made with [Cursor](https://cursor.com)